### PR TITLE
Updating clefspare to new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/ne
 
 https://raw.githubusercontent.com/TheAntiSocialEngineer/AntiSocial-BlockList-UK-Community/main/UK-Community.txt
 
-https://raw.githubusercontent.com/Clefspeare13/pornhosts/master/127.0.0.1/hosts
+https://mypdns.org/clefspeare13/pornhosts/-/raw/master/download_here/127.0.0.1/hosts
 
 https://kriskintel.com/feeds/ktip_covid_domains.txt
 


### PR DESCRIPTION
Since Github took down ~~https://github.com/clefspeare13/pornhosts~~
It have been properly merged to https://mypdns.org/clefspeare13/pornhosts/

However all pi-hole users should really look into https://mypdns.org/my-privacy-dns/porn-records
where they can find some real list for optimal performances throughout the build-in wildcard features
of pi-hole. Which will safe you about 2/3 of all the records = less bandwidth and less CPU load.

I would recommend a mix of the `domains.list` and `wildcard.list` If you are really in need of blocking any domain hosting any porn (This includes otherwise or mostly SFW domains) you should append `strict_adult.list` as well, you should however more or less be prepared to do some manual whitelisting here.

`https://discourse.pi-hole.net/t/the-pihole-command-with-examples/738#wildcarding` says:

```markdown
Whitelist/Blacklist Options:
  -w, whitelist       Whitelist domain(s)
  -b, blacklist       Blacklist domain(s)
  -wild, wildcard     Blacklist domain(s), and all its subdomains
                        Add '-h' for more info on whitelist/blacklist usage

```